### PR TITLE
fix: html tags for the heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <main id="main">
+    <main>
       <div class="card">
         <img
           class="card__image"
@@ -29,9 +29,9 @@
           alt="QR Code linking to frontendmentor.io"
         />
         <div class="card__content">
-          <h1 class="card__title">
+          <h2 class="card__title">
             Improve your front-end skills by building projects
-          </h1>
+          </h2>
           <p class="card__body">
             Scan the QR code to visit Frontend Mentor and take your coding
             skills to the next level

--- a/style.css
+++ b/style.css
@@ -83,9 +83,10 @@ h6 {
 body {
   background-color: var(--clr-lightgray);
   font-family: var(--ff);
+  padding: 10px;
 }
 
-#main {
+main {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -103,6 +104,7 @@ body {
 
 .card__image {
   border-radius: var(--radius-s);
+  width: 100%;
 }
 
 .card__content {


### PR DESCRIPTION
Changed h1 to h2, makes more sense for this component as it shouldn't be the main heading of the web page.

Added a width of 100% on the image. In some case when the page is zoomed at +200% the image was not filling completely the parent container.
